### PR TITLE
WIP bug 1365907 Create test harness for phabricator extensions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,8 @@ services:
       - phabricator.dev
       - bmo.dev
 
-  phabext:
-    image: mozilla/phabext
-
   phabricator:
-    image: mozilla/mozphab
+    image: zalun/phabext
     environment:
       - MYSQL_HOST=phabdb
       - MYSQL_PORT=3306
@@ -33,9 +30,6 @@ services:
     restart: on-failure
     depends_on:
       - phabdb
-      - phabext
-    volumes_from:
-      - phabext
 
   phabricator.dev:
     image: nginx:alpine

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+version: '2'
+services:
+  phabricator:
+    build:
+      context: ../phabricator-extensions
+      dockerfile: ./Dockerfile-test
+    environment:
+      - MYSQL_HOST=phabdb
+      - MYSQL_PORT=3306
+      - MYSQL_USER=root
+      - MYSQL_PASS=password
+      - PHABRICATOR_URI=http://phabricator.dev/
+      - PHABRICATOR_CDN_URI=http://phabricator.dev/
+    restart: on-failure
+    depends_on:
+      - phabdb
+    # volumes:
+    #   - /tmp/phutil_map:/app/phabricator/src/__phutil_library_map__.php
+    #   - /tmp/phutil_init:/app/phabricator/src/__phutil_library_init__.php


### PR DESCRIPTION
Prepares the phabricator container to be able to run `arc unit`

Build the phabricator with attached test config:
$ docker-compose -f docker-compose.yml -f docker-compose/test.yml build phabricator

Copy volume files to /tmp
$ cp docker/phabricator/phutil_* /tmp

Run arc liberate to update the files
$ docker-compose -f docker-compose.yml -f docker-compose/test.yml run phabricator arc-liberate

After that extension tests can be run with
$ docker-compose -f docker-compose.yml -f docker-compose/test.yml run phabricator test-ext