### PR TITLE
Use .test for local hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Interactive demo of Mozilla's code submission pipeline.
     use `arc diff` to submit a review.
  1. In a new terminal, run `firefox-proxy`.  A new browser with an empty
     profile will open.
- 1. Visit `http://phabricator.dev` in the new browser window and log in
+ 1. Visit `http://phabricator.test` in the new browser window and log in
     with `user:phab` and `password:phab` to work with your new review.
 
 Preconfigured users:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 
 version: '2'
 services:
-  bmo.dev:
+  bmo.test:
     image: mozillaconduit/docker-bmo
 
   demo:
@@ -15,8 +15,8 @@ services:
       - .:/home/phab/repo:ro
     depends_on:
       - tinyproxy
-      - phabricator.dev
-      - bmo.dev
+      - phabricator.test
+      - bmo.test
 
   phabext:
     image: mozilla/phabext
@@ -28,8 +28,8 @@ services:
       - MYSQL_PORT=3306
       - MYSQL_USER=root
       - MYSQL_PASS=password
-      - PHABRICATOR_URI=http://phabricator.dev/
-      - PHABRICATOR_CDN_URI=http://phabricator.dev/
+      - PHABRICATOR_URI=http://phabricator.test/
+      - PHABRICATOR_CDN_URI=http://phabricator.test/
     restart: on-failure
     depends_on:
       - phabdb
@@ -37,7 +37,7 @@ services:
     volumes_from:
       - phabext
 
-  phabricator.dev:
+  phabricator.test:
     image: nginx:alpine
     volumes:
       - ./docker/phabricator/site.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker/vct-hg/arcrc
+++ b/docker/vct-hg/arcrc
@@ -1,9 +1,9 @@
 {
   "config": {
-    "phabricator.uri": "http://phabricator.dev"
+    "phabricator.uri": "http://phabricator.test"
   },
   "hosts": {
-    "http://phabricator.dev/api/": {
+    "http://phabricator.test/api/": {
       "token": "cli-wnxaaftwm34jjfheiokqevsshlg7"
     }
   }


### PR DESCRIPTION
We can't use '.dev' or '.local' to name hosts for local development.

'.dev' is a TLD and doesn't work under Vagrant (see https://github.com/Varying-Vagrant-Vagrants/VVV/issues/544).

'.local' clashes with MDNS.

According to RFC 6761 '.test' is reserved for local networks, so
let's use that.