### PR TITLE
Make demo aware of phabricator structure change. (bug 1365907)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,8 @@ services:
       - phabricator.test
       - bmo.test
 
-  phabext:
-    image: mozilla/phabext
-
   phabricator:
-    image: mozilla/mozphab
+    image: mozilla/phabext
     environment:
       - MYSQL_HOST=phabdb
       - MYSQL_PORT=3306
@@ -33,9 +30,6 @@ services:
     restart: on-failure
     depends_on:
       - phabdb
-      - phabext
-    volumes_from:
-      - phabext
 
   phabricator.test:
     image: nginx:alpine


### PR DESCRIPTION
phabext is now extending mozphab container instead of sharing volume
with it.