### PR TITLE
Add lando-api and lando-ui to the demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,39 @@ services:
       - phabricator.test
       - bmo.test
 
+  lando-ui.test:
+    image: mozilla/landoui
+    environment:
+      - HOST=0.0.0.0
+      - PORT=80
+      - OIDC_DOMAIN=oidc_domain_change_me
+      - OIDC_CLIENT_ID=oidc_client_id_change_me
+      - OIDC_CLIENT_SECRET=oidc_client_secret_change_me
+      - SECRET_KEY=secret_key_change_me
+      - SESSION_COOKIE_NAME=lando-ui.test:9000
+      - SESSION_COOKIE_DOMAIN=lando-ui.test:9000
+      - SESSION_COOKIE_SECURE=0
+      - USE_HTTPS=0
+      - LANDO_API_URL=http://lando-api.test:9000
+      - ENV=localdev
+      - SENTRY_DSN=
+      - UWSGI_SOCKET=:9001
+      - UWSGI_HTTP=:9000
+
+  lando-api.test:
+    image: mozilla/landoapi
+    environment:
+      - PORT=80
+      - PHABRICATOR_URL=http://phabricator.test
+      - PHABRICATOR_UNPRIVILEGED_API_KEY=cli-wnxaaftwm34jjfheiokqevsshlg7
+      - TRANSPLANT_URL=https://stub.transplant.example.com
+      - DATABASE_URL=sqlite:////db/sqlite.db
+      - HOST_URL=https://lando-api
+      - ENV=localdev
+      - SENTRY_DSN=
+      - UWSGI_SOCKET=:9001
+      - UWSGI_HTTP=:9000
+
   phabricator:
     image: mozilla/phabext
     environment:


### PR DESCRIPTION
Add the Lando services to the demo.

To test:

1. Run `docker-compose up`
1. Run `./firefox-proxy`
1. Publish a Phabricator diff in phabricator.test.  Note the revision number (e.g. "D1").
1. Visit http://lando-ui.test:9000/revisions/D1