### PR TITLE
Add lando ui and api to the demo environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,18 @@
 
 version: '2'
 services:
+  lando-ui.test:
+    image: jwilder/nginx-proxy
+    container_name: lando-ui.test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  lando-api.test:
+    image: jwilder/nginx-proxy
+    container_name: lando-api.test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
   bmo.test:
     image: mozillaconduit/docker-bmo
 
@@ -18,34 +30,41 @@ services:
       - phabricator.test
       - bmo.test
 
-  lando-ui.test:
+  lando-ui:
     image: mozilla/landoui
     environment:
+      # The VIRTUAL_HOST/PORT is only for the demo, for nginx to proxy on port 80.
+      - VIRTUAL_HOST=lando-ui.test
+      - VIRTUAL_PORT=9000
       - HOST=0.0.0.0
-      - PORT=80
+      - PORT=9000
       - OIDC_DOMAIN=oidc_domain_change_me
       - OIDC_CLIENT_ID=oidc_client_id_change_me
       - OIDC_CLIENT_SECRET=oidc_client_secret_change_me
       - SECRET_KEY=secret_key_change_me
-      - SESSION_COOKIE_NAME=lando-ui.test:9000
-      - SESSION_COOKIE_DOMAIN=lando-ui.test:9000
+      - VERSION_PATH=/app/version.json
+      - SESSION_COOKIE_NAME=lando-ui.test
+      - SESSION_COOKIE_DOMAIN=lando-ui.test
       - SESSION_COOKIE_SECURE=0
       - USE_HTTPS=0
-      - LANDO_API_URL=http://lando-api.test:9000
+      - LANDO_API_URL=http://lando-api.test
       - ENV=localdev
       - SENTRY_DSN=
       - UWSGI_SOCKET=:9001
       - UWSGI_HTTP=:9000
 
-  lando-api.test:
+  lando-api:
     image: mozilla/landoapi
     environment:
-      - PORT=80
+      # The VIRTUAL_HOST/PORT is only for the demo, for nginx to proxy on port 80.
+      - VIRTUAL_HOST=lando-api.test
+      - VIRTUAL_PORT=9000
+      - PORT=9000
       - PHABRICATOR_URL=http://phabricator.test
       - PHABRICATOR_UNPRIVILEGED_API_KEY=cli-wnxaaftwm34jjfheiokqevsshlg7
       - TRANSPLANT_URL=https://stub.transplant.example.com
       - DATABASE_URL=sqlite:////db/sqlite.db
-      - HOST_URL=https://lando-api
+      - HOST_URL=http://lando-api.test
       - ENV=localdev
       - SENTRY_DSN=
       - UWSGI_SOCKET=:9001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,39 @@ services:
       - phabricator.test
       - bmo.test
 
+  lando-ui.test:
+    image: mozilla/landoui
+    environment:
+      - HOST=0.0.0.0
+      - PORT=80
+      - OIDC_DOMAIN=oidc_domain_change_me
+      - OIDC_CLIENT_ID=oidc_client_id_change_me
+      - OIDC_CLIENT_SECRET=oidc_client_secret_change_me
+      - SECRET_KEY=secret_key_change_me
+      - SESSION_COOKIE_NAME=lando-ui.test:9000
+      - SESSION_COOKIE_DOMAIN=lando-ui.test:9000
+      - SESSION_COOKIE_SECURE=0
+      - USE_HTTPS=0
+      - LANDO_API_URL=http://lando-api.test:9000
+      - ENV=localdev
+      - SENTRY_DSN=
+      - UWSGI_SOCKET=:9001
+      - UWSGI_HTTP=:9000
+
+  lando-api.test:
+    image: mozilla/landoapi
+    environment:
+      - PORT=80
+      - PHABRICATOR_URL=http://phabricator.test
+      - PHABRICATOR_UNPRIVILEGED_API_KEY=cli-wnxaaftwm34jjfheiokqevsshlg7
+      - TRANSPLANT_URL=https://stub.transplant.example.com
+      - DATABASE_URL=sqlite:////db/sqlite.db
+      - HOST_URL=https://lando-api
+      - ENV=localdev
+      - SENTRY_DSN=
+      - UWSGI_SOCKET=:9001
+      - UWSGI_HTTP=:9000
+
   phabricator:
     image: mozilla/phabext
     environment:


### PR DESCRIPTION
This is based off of #14 by @mars-f. 

This fixes a few bugs with adding them to the demo environment (namely the missing VERSION_FILE env for lando-ui) 

By adding an nginx reverse proxy for lando ui and lando api, this PR also removes the need for users to memorize the port number to access each service. This also more closely simulates they are deployed in production.


To test:

1. Run `docker-compose up`
1. Run `./firefox-proxy`
1. Publish a Phabricator diff in phabricator.test.  Note the revision number (e.g. "D1").
1. Visit http://lando-ui.test/revisions/D1 (this implicitly calls out to lando-api, so if the api is broken it will show up here).
1. Visit http://lando-api.test for more testing on the api.